### PR TITLE
Show default error activity is no Class is defined in .init()

### DIFF
--- a/library/src/main/java/cat/ereza/customactivityoncrash/CustomActivityOnCrash.java
+++ b/library/src/main/java/cat/ereza/customactivityoncrash/CustomActivityOnCrash.java
@@ -29,6 +29,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.ref.WeakReference;
 
+import cat.ereza.customactivityoncrash.activity.DefaultErrorActivity;
+
 @SuppressLint("NewApi")
 public class CustomActivityOnCrash {
     public static final String EXTRA_STACK_TRACE = "cat.ereza.customactivityoncrash.EXTRA_STACK_TACE";
@@ -51,6 +53,14 @@ public class CustomActivityOnCrash {
     public static void init(Context context, final Class<? extends Activity> errorActivityClass) {
         initInternal(context, errorActivityClass, true);
     }
+    /**
+     * Initializes CustomActivityOnCrash on the application.
+     *
+     * @param context            Context to use for obtaining the ApplicationContext. Must not be null.
+     */
+    public static void init(Context context) {
+        initInternal(context, DefaultErrorActivity.class, true);
+    }
 
     /**
      * Initializes CustomActivityOnCrash on the application.
@@ -61,6 +71,17 @@ public class CustomActivityOnCrash {
      */
     public static void init(Context context, final Class<? extends Activity> errorActivityClass, boolean startActivityEvenIfInBackground) {
         initInternal(context, errorActivityClass, startActivityEvenIfInBackground);
+    }
+
+
+    /**
+     * Initializes CustomActivityOnCrash on the application.
+     *
+     * @param context                         Context to use for obtaining the ApplicationContext. Must not be null.
+     * @param startActivityEvenIfInBackground true if you want to launch the error activity even if the app is in background, false otherwise. This has no effect in API<14 and the activity is always launched.
+     */
+    public static void init(Context context, boolean startActivityEvenIfInBackground) {
+        initInternal(context, DefaultErrorActivity.class, startActivityEvenIfInBackground);
     }
 
     /**

--- a/library/src/main/java/cat/ereza/customactivityoncrash/activity/DefaultErrorActivity.java
+++ b/library/src/main/java/cat/ereza/customactivityoncrash/activity/DefaultErrorActivity.java
@@ -1,0 +1,39 @@
+package cat.ereza.customactivityoncrash.activity;
+
+import android.app.Activity;
+import android.os.Build;
+import android.os.Bundle;
+import android.widget.TextView;
+import android.widget.Toolbar;
+
+import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
+import cat.ereza.customactivityoncrash.R;
+
+/**
+ * Created by a557114 on 22/07/2015.
+ */
+public class DefaultErrorActivity extends Activity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.customactivityoncrash_default_error_activity);
+
+        checkToolbar();
+
+        //Treat here the error as you wish. If you allow the user to restart the app,
+        //don't forget to finish the activity, otherwise you will get the ErrorActivity
+        //on the activity stack and it will be visible again under some circumstances.
+
+        TextView errorDetailsText = (TextView) findViewById(R.id.error_details);
+
+        errorDetailsText.setText(getIntent().getStringExtra(CustomActivityOnCrash.EXTRA_STACK_TRACE));
+    }
+
+    private void checkToolbar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+            setActionBar(toolbar);
+        }
+    }
+}

--- a/library/src/main/res/layout-v21/customactivityoncrash_default_error_activity.xml
+++ b/library/src/main/res/layout-v21/customactivityoncrash_default_error_activity.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?android:attr/colorPrimary"
+        android:minHeight="?android:attr/actionBarSize"
+        android:popupTheme="@android:style/android:Theme.Material.Light"
+        android:theme="@style/CustomActivityOnCrashTheme" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingBottom="@dimen/activity_vertical_margin"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin">
+
+        <ScrollView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:fillViewport="true">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/error_occurred"
+                    android:textSize="18sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="20dp"
+                    android:text="@string/error_details"
+                    android:textStyle="bold" />
+
+
+                <TextView
+                    android:id="@+id/error_details"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
+                    android:text="@string/unknown_exception" />
+            </LinearLayout>
+        </ScrollView>
+    </LinearLayout>
+
+</LinearLayout>

--- a/library/src/main/res/layout/customactivityoncrash_default_error_activity.xml
+++ b/library/src/main/res/layout/customactivityoncrash_default_error_activity.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingBottom="@dimen/activity_vertical_margin"
+    android:paddingLeft="@dimen/activity_horizontal_margin"
+    android:paddingRight="@dimen/activity_horizontal_margin"
+    android:paddingTop="@dimen/activity_vertical_margin">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/error_occurred"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="20dp"
+                android:text="@string/error_details"
+                android:textStyle="bold" />
+
+
+            <TextView
+                android:id="@+id/error_details"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/unknown_exception" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/library/src/main/res/values-v14/styles.xml
+++ b/library/src/main/res/values-v14/styles.xml
@@ -14,17 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cat.ereza.customactivityoncrash">
+<resources>
 
-    <application>
+    <style name="CustomActivityOnCrashTheme" parent="android:Theme.Holo.Light.DarkActionBar" />
 
-        <activity
-            android:name="cat.ereza.customactivityoncrash.activity.DefaultErrorActivity"
-            android:theme="@style/CustomActivityOnCrashTheme"
-            android:process=":error_report"
-            android:label="@string/CustomActivityOnCrash_ErrorActivity_title"/>
-
-    </application>
-
-</manifest>
+</resources>

--- a/library/src/main/res/values-v21/styles.xml
+++ b/library/src/main/res/values-v21/styles.xml
@@ -14,17 +14,10 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cat.ereza.customactivityoncrash">
-
-    <application>
-
-        <activity
-            android:name="cat.ereza.customactivityoncrash.activity.DefaultErrorActivity"
-            android:theme="@style/CustomActivityOnCrashTheme"
-            android:process=":error_report"
-            android:label="@string/CustomActivityOnCrash_ErrorActivity_title"/>
-
-    </application>
-
-</manifest>
+<resources>
+    <style name="CustomActivityOnCrashTheme" parent="android:Theme.Material.NoActionBar">
+        <item name="android:colorPrimary">@color/CustomActivityOnCrash_primary</item>
+        <item name="android:colorPrimaryDark">@color/CustomActivityOnCrash_primaryDark</item>
+        <item name="android:colorAccent">@color/CustomActivityOnCrash_accent</item>
+    </style>
+</resources>

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="CustomActivityOnCrash_primary">#3F51B5</color>
+    <color name="CustomActivityOnCrash_primaryDark">#283593</color>
+    <color name="CustomActivityOnCrash_accent">#FF4081</color>
+</resources>

--- a/library/src/main/res/values/dimens.xml
+++ b/library/src/main/res/values/dimens.xml
@@ -14,17 +14,10 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cat.ereza.customactivityoncrash">
+<resources>
 
-    <application>
+    <!-- Default screen margins, per the Android Design guidelines. -->
+    <dimen name="activity_horizontal_margin">16dp</dimen>
+    <dimen name="activity_vertical_margin">16dp</dimen>
 
-        <activity
-            android:name="cat.ereza.customactivityoncrash.activity.DefaultErrorActivity"
-            android:theme="@style/CustomActivityOnCrashTheme"
-            android:process=":error_report"
-            android:label="@string/CustomActivityOnCrash_ErrorActivity_title"/>
-
-    </application>
-
-</manifest>
+</resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2015 Eduard Ereza Martínez
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~
+  ~ You may obtain a copy of the License at
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+
+    <string name="app_name">Custom Activity on Crash Sample</string>
+    <string name="hello">Hello! Press one of the following buttons to crash the app:</string>
+    <string name="crash_main_thread">Crash main thread</string>
+    <string name="crash_background_thread">Crash background thread</string>
+    <string name="crash_with_delay">Crash with delay (5s)</string>
+    <string name="error_occurred">An error occurred. We\'re deeply sorry.</string>
+    <string name="error_details">Error details:</string>
+    <string name="unknown_exception">Unknown exception</string>
+    <string name="restart_app">Restart app</string>
+    <string name="error_title">Something went wrong!</string>
+    <string name="CustomActivityOnCrash_ErrorActivity_title">Error Activity</string>
+
+</resources>

--- a/library/src/main/res/values/styles.xml
+++ b/library/src/main/res/values/styles.xml
@@ -14,17 +14,8 @@
   ~ limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="cat.ereza.customactivityoncrash">
+<resources>
 
-    <application>
+    <style name="CustomActivityOnCrashTheme" parent="android:Theme.Light" />
 
-        <activity
-            android:name="cat.ereza.customactivityoncrash.activity.DefaultErrorActivity"
-            android:theme="@style/CustomActivityOnCrashTheme"
-            android:process=":error_report"
-            android:label="@string/CustomActivityOnCrash_ErrorActivity_title"/>
-
-    </application>
-
-</manifest>
+</resources>

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashableApplication.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashableApplication.java
@@ -27,7 +27,7 @@ public class SampleCrashableApplication extends Application {
         super.onCreate();
 
         //Install CustomActivityOnCrash
-        CustomActivityOnCrash.init(this, ErrorActivity.class, true);
+        CustomActivityOnCrash.init(this, true);
 
         //Now initialize your error handlers as normal, they will most likely keep a reference to the original exception handler
         //i.e., ACRA.init(this);


### PR DESCRIPTION
This should be tested before merge it.

Maybe, it needs a way to handle "restart" the app in the default error view, we can discuss that

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/ereza/customactivityoncrash/3)
<!-- Reviewable:end -->
