### PR TITLE
Ability to find class if Main Class is not mentioned through Intent F…

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -27,8 +27,9 @@
             android:name="cat.ereza.sample.customactivityoncrash.activity.MainActivity"
             android:label="@string/app_name">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LAUNCHER" />
+                <action android:name="android.intent.action.MAIN"/>
+                <category android:name="android.intent.category.LAUNCHER"/>
+                <!--<action android:name="cat.ereza.customactivityoncrash.ERROR"/>-->
             </intent-filter>
         </activity>
 

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashingApplication.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashingApplication.java
@@ -34,7 +34,7 @@ public class SampleCrashingApplication extends Application {
         CustomActivityOnCrash.setLaunchActivityEvenIfInBackground(false);
 
         //This sets the restart activity. If you don't do this, the "Restart app" button will change to "Close app".
-        CustomActivityOnCrash.setRestartActivityClass(MainActivity.class);
+//        CustomActivityOnCrash.setRestartActivityClass(MainActivity.class);
 
         //This hides the "error details" button, thus hiding the stack trace
 //        CustomActivityOnCrash.setShowErrorDetails(false);

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashingApplication.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/SampleCrashingApplication.java
@@ -34,6 +34,8 @@ public class SampleCrashingApplication extends Application {
         CustomActivityOnCrash.setLaunchActivityEvenIfInBackground(false);
 
         //This sets the restart activity. If you don't do this, the "Restart app" button will change to "Close app".
+        //You can define class with Intent Filter cat.ereza.customactivityoncrash.ERROR or it will get default launcher app
+        //otherwise you can set class as follwing.
 //        CustomActivityOnCrash.setRestartActivityClass(MainActivity.class);
 
         //This hides the "error details" button, thus hiding the stack trace

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
@@ -71,7 +71,5 @@ public class MainActivity extends Activity {
                 }.execute();
             }
         });
-
-        CustomActivityOnCrash.install(this);
     }
 }

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
@@ -22,6 +22,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
+import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
 import cat.ereza.sample.customactivityoncrash.R;
 
 public class MainActivity extends Activity {
@@ -70,5 +71,7 @@ public class MainActivity extends Activity {
                 }.execute();
             }
         });
+
+        CustomActivityOnCrash.install(this);
     }
 }

--- a/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
+++ b/sample/src/main/java/cat/ereza/sample/customactivityoncrash/activity/MainActivity.java
@@ -22,7 +22,6 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 
-import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
 import cat.ereza.sample.customactivityoncrash.R;
 
 public class MainActivity extends Activity {


### PR DESCRIPTION
…ilter action android:name="cat.ereza.customactivityoncrash.ERROR" or find the Main Launcher class. You can disable this beheviour ifyou don't want user to restart your app by calling method disableAppRestart then it will show a close button instead of a restart button.

https://github.com/Ereza/CustomActivityOnCrash/issues/5