### PR TITLE
add codes for clearing current activity stack before showing crash activity

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -24,6 +24,8 @@
             android:process=":error_activity"
             android:theme="@style/CustomActivityOnCrashTheme" />
 
+        <activity android:name=".activity.ClearStack"></activity>
+
     </application>
 
 </manifest>

--- a/library/src/main/java/cat/ereza/customactivityoncrash/CustomActivityOnCrash.java
+++ b/library/src/main/java/cat/ereza/customactivityoncrash/CustomActivityOnCrash.java
@@ -41,20 +41,28 @@ import java.util.Locale;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import cat.ereza.customactivityoncrash.activity.ClearStack;
 import cat.ereza.customactivityoncrash.activity.DefaultErrorActivity;
 
 @SuppressLint("NewApi")
-public final class CustomActivityOnCrash {
+public final class CustomActivityOnCrash
+{
     //Extras passed to the error activity
-    private static final String EXTRA_RESTART_ACTIVITY_CLASS = "cat.ereza.customactivityoncrash.EXTRA_RESTART_ACTIVITY_CLASS";
-    private static final String EXTRA_SHOW_ERROR_DETAILS = "cat.ereza.customactivityoncrash.EXTRA_SHOW_ERROR_DETAILS";
-    private static final String EXTRA_STACK_TRACE = "cat.ereza.customactivityoncrash.EXTRA_STACK_TRACE";
+    private static final String EXTRA_RESTART_ACTIVITY_CLASS =
+            "cat.ereza.customactivityoncrash.EXTRA_RESTART_ACTIVITY_CLASS";
+    private static final String EXTRA_SHOW_ERROR_DETAILS =
+            "cat.ereza.customactivityoncrash.EXTRA_SHOW_ERROR_DETAILS";
+    private static final String EXTRA_STACK_TRACE =
+            "cat.ereza.customactivityoncrash.EXTRA_STACK_TRACE";
 
     //General constants
     private final static String TAG = "CustomActivityOnCrash";
-    private static final String INTENT_ACTION_ERROR_ACTIVITY = "cat.ereza.customactivityoncrash.ERROR";
-    private static final String INTENT_ACTION_RESTART_ACTIVITY = "cat.ereza.customactivityoncrash.RESTART";
-    private static final String CAOC_HANDLER_PACKAGE_NAME = "cat.ereza.customactivityoncrash";
+    private static final String INTENT_ACTION_ERROR_ACTIVITY =
+            "cat.ereza.customactivityoncrash.ERROR";
+    private static final String INTENT_ACTION_RESTART_ACTIVITY =
+            "cat.ereza.customactivityoncrash.RESTART";
+    private static final String CAOC_HANDLER_PACKAGE_NAME =
+            "cat.ereza.customactivityoncrash";
     private static final String DEFAULT_HANDLER_PACKAGE_NAME = "com.android.internal.os";
     private static final int MAX_STACK_TRACE_SIZE = 131071; //128 KB - 1
 
@@ -70,47 +78,67 @@ public final class CustomActivityOnCrash {
     private static Class<? extends Activity> errorActivityClass = null;
     private static Class<? extends Activity> restartActivityClass = null;
 
+    public static final String KEY_CURRENT_INTENT =
+            "cat.ereza.customactivityoncrash.EXTRA_KEY_CURRENT_INTENT";
+
     /**
      * Installs CustomActivityOnCrash on the application using the default error activity.
      *
      * @param context Context to use for obtaining the ApplicationContext. Must not be null.
      */
-    public static void install(Context context) {
-        try {
-            if (context == null) {
+    public static void install(Context context)
+    {
+        try
+        {
+            if (context == null)
+            {
                 Log.e(TAG, "Install failed: context is null!");
-            } else {
-                if (android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
+            } else
+            {
+                if (android.os.Build.VERSION.SDK_INT <
+                        Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+                {
                     Log.w(TAG, "CustomActivityOnCrash will be installed, but may not be reliable in API lower than 14");
                 }
 
                 //INSTALL!
                 Thread.UncaughtExceptionHandler oldHandler = Thread.getDefaultUncaughtExceptionHandler();
 
-                if (oldHandler != null && oldHandler.getClass().getName().startsWith(CAOC_HANDLER_PACKAGE_NAME)) {
+                if (oldHandler != null && oldHandler.getClass().getName().startsWith(CAOC_HANDLER_PACKAGE_NAME))
+                {
                     Log.e(TAG, "You have already installed CustomActivityOnCrash, doing nothing!");
-                } else {
-                    if (oldHandler != null && !oldHandler.getClass().getName().startsWith(DEFAULT_HANDLER_PACKAGE_NAME)) {
+                } else
+                {
+                    if (oldHandler != null && !oldHandler.getClass().getName().startsWith(DEFAULT_HANDLER_PACKAGE_NAME))
+                    {
                         Log.e(TAG, "IMPORTANT WARNING! You already have an UncaughtExceptionHandler, are you sure this is correct? If you use ACRA, Crashlytics or similar libraries, you must initialize them AFTER CustomActivityOnCrash! Installing anyway, but your original handler will not be called.");
                     }
 
                     application = (Application) context.getApplicationContext();
 
                     //We define a default exception handler that does what we want so it can be called from Crashlytics/ACRA
-                    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
+                    Thread.setDefaultUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler()
+                    {
                         @Override
-                        public void uncaughtException(Thread thread, final Throwable throwable) {
+                        public void uncaughtException(Thread thread, final Throwable throwable)
+                        {
                             Log.e(TAG, "App has crashed, executing CustomActivityOnCrash's UncaughtExceptionHandler", throwable);
 
-                            if (errorActivityClass == null) {
+                            if (errorActivityClass == null)
+                            {
                                 errorActivityClass = guessErrorActivityClass(application);
                             }
 
-                            if (isStackTraceLikelyConflictive(throwable, errorActivityClass)) {
-                                Log.e(TAG, "Your application class or your error activity have crashed, the custom activity will not be launched!");
-                            } else {
-                                if (launchErrorActivityWhenInBackground || !isInBackground) {
+                            if (isStackTraceLikelyConflictive(throwable, errorActivityClass))
+                            {
+                                Log.e(TAG, "Your application class or your error activity have crashed, " +
+                                        "the custom activity will not be launched!");
+                            } else
+                            {
+                                if (launchErrorActivityWhenInBackground || !isInBackground)
+                                {
                                     final Intent intent = new Intent(application, errorActivityClass);
+
                                     StringWriter sw = new StringWriter();
                                     PrintWriter pw = new PrintWriter(sw);
                                     throwable.printStackTrace(pw);
@@ -120,16 +148,19 @@ public final class CustomActivityOnCrash {
                                     //The limit is 1MB on Android but some devices seem to have it lower.
                                     //See: http://developer.android.com/reference/android/os/TransactionTooLargeException.html
                                     //And: http://stackoverflow.com/questions/11451393/what-to-do-on-transactiontoolargeexception#comment46697371_12809171
-                                    if (stackTraceString.length() > MAX_STACK_TRACE_SIZE) {
+                                    if (stackTraceString.length() > MAX_STACK_TRACE_SIZE)
+                                    {
                                         String disclaimer = " [stack trace too large]";
                                         stackTraceString = stackTraceString.substring(0, MAX_STACK_TRACE_SIZE - disclaimer.length()) + disclaimer;
                                     }
 
-                                    if (enableAppRestart && restartActivityClass == null) {
+                                    if (enableAppRestart && restartActivityClass == null)
+                                    {
                                         //We can set the restartActivityClass because the app will terminate right now,
                                         //and when relaunched, will be null again by default.
                                         restartActivityClass = guessRestartActivityClass(application);
-                                    } else if (!enableAppRestart) {
+                                    } else if (!enableAppRestart)
+                                    {
                                         //In case someone sets the activity and then decides to not restart
                                         restartActivityClass = null;
                                     }
@@ -138,11 +169,18 @@ public final class CustomActivityOnCrash {
                                     intent.putExtra(EXTRA_RESTART_ACTIVITY_CLASS, restartActivityClass);
                                     intent.putExtra(EXTRA_SHOW_ERROR_DETAILS, showErrorDetails);
                                     intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                                    application.startActivity(intent);
+                                    // application.startActivity(intent);
+
+                                    Intent clearIntent = new Intent(application, ClearStack.class);
+                                    clearIntent.putExtra(KEY_CURRENT_INTENT, intent);
+                                    clearStack(application, clearIntent);//clear current stacks
+
+
                                 }
                             }
                             final Activity lastActivity = lastActivityCreated.get();
-                            if (lastActivity != null) {
+                            if (lastActivity != null)
+                            {
                                 //We finish the activity, this solves a bug which causes infinite recursion.
                                 //This is unsolvable in API<14, so beware!
                                 //See: https://github.com/ACRA/acra/issues/42
@@ -153,13 +191,17 @@ public final class CustomActivityOnCrash {
                             System.exit(10);
                         }
                     });
-                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH) {
-                        application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
+                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH)
+                    {
+                        application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks()
+                        {
                             int currentlyStartedActivities = 0;
 
                             @Override
-                            public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
-                                if (activity.getClass() != errorActivityClass) {
+                            public void onActivityCreated(Activity activity, Bundle savedInstanceState)
+                            {
+                                if (activity.getClass() != errorActivityClass)
+                                {
                                     // Copied from ACRA:
                                     // Ignore activityClass because we want the last
                                     // application Activity that was started so that we can
@@ -169,36 +211,42 @@ public final class CustomActivityOnCrash {
                             }
 
                             @Override
-                            public void onActivityStarted(Activity activity) {
+                            public void onActivityStarted(Activity activity)
+                            {
                                 currentlyStartedActivities++;
                                 isInBackground = (currentlyStartedActivities == 0);
                                 //Do nothing
                             }
 
                             @Override
-                            public void onActivityResumed(Activity activity) {
+                            public void onActivityResumed(Activity activity)
+                            {
                                 //Do nothing
                             }
 
                             @Override
-                            public void onActivityPaused(Activity activity) {
+                            public void onActivityPaused(Activity activity)
+                            {
                                 //Do nothing
                             }
 
                             @Override
-                            public void onActivityStopped(Activity activity) {
+                            public void onActivityStopped(Activity activity)
+                            {
                                 //Do nothing
                                 currentlyStartedActivities--;
                                 isInBackground = (currentlyStartedActivities == 0);
                             }
 
                             @Override
-                            public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+                            public void onActivitySaveInstanceState(Activity activity, Bundle outState)
+                            {
                                 //Do nothing
                             }
 
                             @Override
-                            public void onActivityDestroyed(Activity activity) {
+                            public void onActivityDestroyed(Activity activity)
+                            {
                                 //Do nothing
                             }
                         });
@@ -207,9 +255,23 @@ public final class CustomActivityOnCrash {
                     Log.i(TAG, "CustomActivityOnCrash has been installed.");
                 }
             }
-        } catch (Throwable t) {
+        } catch (Throwable t)
+        {
             Log.e(TAG, "An unknown error occurred while installing CustomActivityOnCrash, it may not have been properly initialized. Please report this as a bug if needed.", t);
         }
+    }
+
+    /**
+     * clear current activity stack
+     *
+     * @param context
+     * @param intent
+     */
+    private static void clearStack(Context context, Intent intent)
+    {
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+        intent.addCategory(Intent.CATEGORY_DEFAULT);
+        context.startActivity(intent);
     }
 
     /**
@@ -218,7 +280,8 @@ public final class CustomActivityOnCrash {
      * @param intent The Intent. Must not be null.
      * @return true if the button must be shown, false otherwise.
      */
-    public static boolean isShowErrorDetailsFromIntent(Intent intent) {
+    public static boolean isShowErrorDetailsFromIntent(Intent intent)
+    {
         return intent.getBooleanExtra(CustomActivityOnCrash.EXTRA_SHOW_ERROR_DETAILS, true);
     }
 
@@ -228,7 +291,8 @@ public final class CustomActivityOnCrash {
      * @param intent The Intent. Must not be null.
      * @return The stacktrace, or null if not provided.
      */
-    public static String getStackTraceFromIntent(Intent intent) {
+    public static String getStackTraceFromIntent(Intent intent)
+    {
         return intent.getStringExtra(CustomActivityOnCrash.EXTRA_STACK_TRACE);
     }
 
@@ -239,7 +303,8 @@ public final class CustomActivityOnCrash {
      * @param intent  The Intent. Must not be null.
      * @return The full error details.
      */
-    public static String getAllErrorDetailsFromIntent(Context context, Intent intent) {
+    public static String getAllErrorDetailsFromIntent(Context context, Intent intent)
+    {
         //I don't think that this needs localization because it's a development string...
 
         Date currentDate = new Date();
@@ -269,12 +334,15 @@ public final class CustomActivityOnCrash {
      * @return The restart activity class, or null if not provided.
      */
     @SuppressWarnings("unchecked")
-    public static Class<? extends Activity> getRestartActivityClassFromIntent(Intent intent) {
+    public static Class<? extends Activity> getRestartActivityClassFromIntent(Intent intent)
+    {
         Serializable serializedClass = intent.getSerializableExtra(CustomActivityOnCrash.EXTRA_RESTART_ACTIVITY_CLASS);
 
-        if (serializedClass != null && serializedClass instanceof Class) {
+        if (serializedClass != null && serializedClass instanceof Class)
+        {
             return (Class<? extends Activity>) serializedClass;
-        } else {
+        } else
+        {
             return null;
         }
     }
@@ -287,7 +355,8 @@ public final class CustomActivityOnCrash {
      *
      * @return true if it will be launched, false otherwise.
      */
-    public static boolean isLaunchErrorActivityWhenInBackground() {
+    public static boolean isLaunchErrorActivityWhenInBackground()
+    {
         return launchErrorActivityWhenInBackground;
     }
 
@@ -298,7 +367,8 @@ public final class CustomActivityOnCrash {
      * This has no effect in API<14 and the error activity is always launched.
      * The default is true (the app will be brought to front when a crash occurs).
      */
-    public static void setLaunchErrorActivityWhenInBackground(boolean launchErrorActivityWhenInBackground) {
+    public static void setLaunchErrorActivityWhenInBackground(boolean launchErrorActivityWhenInBackground)
+    {
         CustomActivityOnCrash.launchErrorActivityWhenInBackground = launchErrorActivityWhenInBackground;
     }
 
@@ -307,7 +377,8 @@ public final class CustomActivityOnCrash {
      *
      * @return true if it will be shown, false otherwise.
      */
-    public static boolean isShowErrorDetails() {
+    public static boolean isShowErrorDetails()
+    {
         return showErrorDetails;
     }
 
@@ -317,7 +388,8 @@ public final class CustomActivityOnCrash {
      * false if you want it to be hidden.
      * The default is true.
      */
-    public static void setShowErrorDetails(boolean showErrorDetails) {
+    public static void setShowErrorDetails(boolean showErrorDetails)
+    {
         CustomActivityOnCrash.showErrorDetails = showErrorDetails;
     }
 
@@ -328,7 +400,8 @@ public final class CustomActivityOnCrash {
      *
      * @return true if a restart button should be shown, false if a close button must be used.
      */
-    public static boolean isEnableAppRestart() {
+    public static boolean isEnableAppRestart()
+    {
         return enableAppRestart;
     }
 
@@ -340,7 +413,8 @@ public final class CustomActivityOnCrash {
      * In that case, a close button will still be used.
      * The default is true.
      */
-    public static void setEnableAppRestart(boolean enableAppRestart) {
+    public static void setEnableAppRestart(boolean enableAppRestart)
+    {
         CustomActivityOnCrash.enableAppRestart = enableAppRestart;
     }
 
@@ -349,7 +423,8 @@ public final class CustomActivityOnCrash {
      *
      * @return The class, or null if not set.
      */
-    public static Class<? extends Activity> getErrorActivityClass() {
+    public static Class<? extends Activity> getErrorActivityClass()
+    {
         return errorActivityClass;
     }
 
@@ -357,7 +432,8 @@ public final class CustomActivityOnCrash {
      * Sets the error activity class to launch when a crash occurs.
      * If null,the default error activity will be used.
      */
-    public static void setErrorActivityClass(Class<? extends Activity> errorActivityClass) {
+    public static void setErrorActivityClass(Class<? extends Activity> errorActivityClass)
+    {
         CustomActivityOnCrash.errorActivityClass = errorActivityClass;
     }
 
@@ -366,7 +442,8 @@ public final class CustomActivityOnCrash {
      *
      * @return The class, or null if not set.
      */
-    public static Class<? extends Activity> getRestartActivityClass() {
+    public static Class<? extends Activity> getRestartActivityClass()
+    {
         return restartActivityClass;
     }
 
@@ -374,7 +451,8 @@ public final class CustomActivityOnCrash {
      * Sets the main activity class that the error activity must launch when a crash occurs.
      * If not set or set to null, the default error activity will close instead.
      */
-    public static void setRestartActivityClass(Class<? extends Activity> restartActivityClass) {
+    public static void setRestartActivityClass(Class<? extends Activity> restartActivityClass)
+    {
         CustomActivityOnCrash.restartActivityClass = restartActivityClass;
     }
 
@@ -390,11 +468,15 @@ public final class CustomActivityOnCrash {
      * @param activityClass The activity class to launch when the app crashes
      * @return true if this stack trace is conflictive and the activity must not be launched, false otherwise
      */
-    private static boolean isStackTraceLikelyConflictive(Throwable throwable, Class<? extends Activity> activityClass) {
-        do {
+    private static boolean isStackTraceLikelyConflictive(Throwable throwable, Class<? extends Activity> activityClass)
+    {
+        do
+        {
             StackTraceElement[] stackTrace = throwable.getStackTrace();
-            for (StackTraceElement element : stackTrace) {
-                if ((element.getClassName().equals("android.app.ActivityThread") && element.getMethodName().equals("handleBindApplication")) || element.getClassName().equals(activityClass.getName())) {
+            for (StackTraceElement element : stackTrace)
+            {
+                if ((element.getClassName().equals("android.app.ActivityThread") && element.getMethodName().equals("handleBindApplication")) || element.getClassName().equals(activityClass.getName()))
+                {
                     return true;
                 }
             }
@@ -409,16 +491,19 @@ public final class CustomActivityOnCrash {
      * @param dateFormat DateFormat to use to convert from Date to String
      * @return The formatted date, or "Unknown" if unable to determine it.
      */
-    private static String getBuildDateAsString(Context context, DateFormat dateFormat) {
+    private static String getBuildDateAsString(Context context, DateFormat dateFormat)
+    {
         String buildDate;
-        try {
+        try
+        {
             ApplicationInfo ai = context.getPackageManager().getApplicationInfo(context.getPackageName(), 0);
             ZipFile zf = new ZipFile(ai.sourceDir);
             ZipEntry ze = zf.getEntry("classes.dex");
             long time = ze.getTime();
             buildDate = dateFormat.format(new Date(time));
             zf.close();
-        } catch (Exception e) {
+        } catch (Exception e)
+        {
             buildDate = "Unknown";
         }
         return buildDate;
@@ -430,11 +515,14 @@ public final class CustomActivityOnCrash {
      * @param context A valid context. Must not be null.
      * @return The version name, or "Unknown if unable to determine it.
      */
-    private static String getVersionName(Context context) {
-        try {
+    private static String getVersionName(Context context)
+    {
+        try
+        {
             PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
             return packageInfo.versionName;
-        } catch (Exception e) {
+        } catch (Exception e)
+        {
             return "Unknown";
         }
     }
@@ -445,12 +533,15 @@ public final class CustomActivityOnCrash {
      *
      * @return The device model name (i.e., "LGE Nexus 5")
      */
-    private static String getDeviceModelName() {
+    private static String getDeviceModelName()
+    {
         String manufacturer = Build.MANUFACTURER;
         String model = Build.MODEL;
-        if (model.startsWith(manufacturer)) {
+        if (model.startsWith(manufacturer))
+        {
             return capitalize(model);
-        } else {
+        } else
+        {
             return capitalize(manufacturer) + " " + model;
         }
     }
@@ -461,14 +552,18 @@ public final class CustomActivityOnCrash {
      * @param s The string to capitalize
      * @return The capitalized string
      */
-    private static String capitalize(String s) {
-        if (s == null || s.length() == 0) {
+    private static String capitalize(String s)
+    {
+        if (s == null || s.length() == 0)
+        {
             return "";
         }
         char first = s.charAt(0);
-        if (Character.isUpperCase(first)) {
+        if (Character.isUpperCase(first))
+        {
             return s;
-        } else {
+        } else
+        {
             return Character.toUpperCase(first) + s.substring(1);
         }
     }
@@ -482,14 +577,16 @@ public final class CustomActivityOnCrash {
      * @param context A valid context. Must not be null.
      * @return The guessed restart activity class, or null if no suitable one is found
      */
-    private static Class<? extends Activity> guessRestartActivityClass(Context context) {
+    private static Class<? extends Activity> guessRestartActivityClass(Context context)
+    {
         Class<? extends Activity> resolvedActivityClass;
 
         //If action is defined, use that
         resolvedActivityClass = CustomActivityOnCrash.getRestartActivityClassWithIntentFilter(context);
 
         //Else, get the default launcher activity
-        if (resolvedActivityClass == null) {
+        if (resolvedActivityClass == null)
+        {
             resolvedActivityClass = getLauncherActivity(context);
         }
 
@@ -504,16 +601,20 @@ public final class CustomActivityOnCrash {
      * @return A valid activity class, or null if no suitable one is found
      */
     @SuppressWarnings("unchecked")
-    private static Class<? extends Activity> getRestartActivityClassWithIntentFilter(Context context) {
+    private static Class<? extends Activity> getRestartActivityClassWithIntentFilter(Context context)
+    {
         List<ResolveInfo> resolveInfos = context.getPackageManager().queryIntentActivities(
                 new Intent().setAction(INTENT_ACTION_RESTART_ACTIVITY),
                 PackageManager.GET_RESOLVED_FILTER);
 
-        if (resolveInfos != null && resolveInfos.size() > 0) {
+        if (resolveInfos != null && resolveInfos.size() > 0)
+        {
             ResolveInfo resolveInfo = resolveInfos.get(0);
-            try {
+            try
+            {
                 return (Class<? extends Activity>) Class.forName(resolveInfo.activityInfo.name);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException e)
+            {
                 //Should not happen, print it to the log!
                 Log.e(TAG, "Failed when resolving the restart activity class via intent filter, stack trace follows!", e);
             }
@@ -530,12 +631,16 @@ public final class CustomActivityOnCrash {
      * @return A valid activity class, or null if no suitable one is found
      */
     @SuppressWarnings("unchecked")
-    private static Class<? extends Activity> getLauncherActivity(Context context) {
+    private static Class<? extends Activity> getLauncherActivity(Context context)
+    {
         Intent intent = context.getPackageManager().getLaunchIntentForPackage(context.getPackageName());
-        if (intent != null) {
-            try {
+        if (intent != null)
+        {
+            try
+            {
                 return (Class<? extends Activity>) Class.forName(intent.getComponent().getClassName());
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException e)
+            {
                 //Should not happen, print it to the log!
                 Log.e(TAG, "Failed when resolving the restart activity class via getLaunchIntentForPackage, stack trace follows!", e);
             }
@@ -553,14 +658,16 @@ public final class CustomActivityOnCrash {
      * @param context A valid context. Must not be null.
      * @return The guessed error activity class, or the default error activity if not found
      */
-    private static Class<? extends Activity> guessErrorActivityClass(Context context) {
+    private static Class<? extends Activity> guessErrorActivityClass(Context context)
+    {
         Class<? extends Activity> resolvedActivityClass;
 
         //If action is defined, use that
         resolvedActivityClass = CustomActivityOnCrash.getErrorActivityClassWithIntentFilter(context);
 
         //Else, get the default launcher activity
-        if (resolvedActivityClass == null) {
+        if (resolvedActivityClass == null)
+        {
             resolvedActivityClass = DefaultErrorActivity.class;
         }
 
@@ -575,16 +682,20 @@ public final class CustomActivityOnCrash {
      * @return A valid activity class, or null if no suitable one is found
      */
     @SuppressWarnings("unchecked")
-    private static Class<? extends Activity> getErrorActivityClassWithIntentFilter(Context context) {
+    private static Class<? extends Activity> getErrorActivityClassWithIntentFilter(Context context)
+    {
         List<ResolveInfo> resolveInfos = context.getPackageManager().queryIntentActivities(
                 new Intent().setAction(INTENT_ACTION_ERROR_ACTIVITY),
                 PackageManager.GET_RESOLVED_FILTER);
 
-        if (resolveInfos != null && resolveInfos.size() > 0) {
+        if (resolveInfos != null && resolveInfos.size() > 0)
+        {
             ResolveInfo resolveInfo = resolveInfos.get(0);
-            try {
+            try
+            {
                 return (Class<? extends Activity>) Class.forName(resolveInfo.activityInfo.name);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException e)
+            {
                 //Should not happen, print it to the log!
                 Log.e(TAG, "Failed when resolving the error activity class via intent filter, stack trace follows!", e);
             }

--- a/library/src/main/java/cat/ereza/customactivityoncrash/activity/ClearStack.java
+++ b/library/src/main/java/cat/ereza/customactivityoncrash/activity/ClearStack.java
@@ -1,0 +1,26 @@
+package cat.ereza.customactivityoncrash.activity;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
+
+/**
+ * Created by zhy on 15/8/4.
+ */
+public class ClearStack extends Activity
+{
+
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+
+        Intent intent = getIntent().getParcelableExtra(CustomActivityOnCrash.KEY_CURRENT_INTENT);
+        startActivity(intent);
+        finish();
+        Runtime.getRuntime().exit(0);
+    }
+}


### PR DESCRIPTION
for example:

Activity A -> Activity B -> Activity C , now throw a RuntimeException and show CrashActivity . But when users click back key , they would see Activity B , this will make them confused. And if they click restart button , it worse , because Activity A , Activity B would still in stack . 

So , i add some codes for clearing current stack before showing  crash activity . 