### PR TITLE
Copy error information to clipboard

### DIFF
--- a/library/src/main/java/cat/ereza/customactivityoncrash/activity/DefaultErrorActivity.java
+++ b/library/src/main/java/cat/ereza/customactivityoncrash/activity/DefaultErrorActivity.java
@@ -16,15 +16,21 @@
 
 package cat.ereza.customactivityoncrash.activity;
 
+import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.util.TypedValue;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
 
+import android.widget.Toast;
 import cat.ereza.customactivityoncrash.CustomActivityOnCrash;
 import cat.ereza.customactivityoncrash.R;
 
@@ -75,6 +81,13 @@ public final class DefaultErrorActivity extends Activity {
                             .setTitle(R.string.customactivityoncrash_error_activity_error_details_title)
                             .setMessage(CustomActivityOnCrash.getAllErrorDetailsFromIntent(DefaultErrorActivity.this, getIntent()))
                             .setPositiveButton(R.string.customactivityoncrash_error_activity_error_details_close, null)
+                            .setNeutralButton(R.string.customactivityoncrash_error_activity_error_details_copy,
+                              new DialogInterface.OnClickListener() {
+                                  @Override public void onClick(DialogInterface dialog, int which) {
+                                      copyErrorToClipboard();
+                                      Toast.makeText(DefaultErrorActivity.this, R.string.customactivityoncrash_error_activity_error_details_copied, Toast.LENGTH_SHORT).show();
+                                  }
+                              })
                             .show();
                     TextView textView = (TextView) dialog.findViewById(android.R.id.message);
                     textView.setTextSize(TypedValue.COMPLEX_UNIT_PX, getResources().getDimension(R.dimen.customactivityoncrash_error_activity_error_details_text_size));
@@ -82,6 +95,21 @@ public final class DefaultErrorActivity extends Activity {
             });
         } else {
             moreInfoButton.setVisibility(View.GONE);
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private void copyErrorToClipboard() {
+        String errorInformation =
+          CustomActivityOnCrash.getAllErrorDetailsFromIntent(DefaultErrorActivity.this, getIntent());
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+            android.text.ClipboardManager clipboard = (android.text.ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+            clipboard.setText(errorInformation);
+        } else {
+            ClipboardManager clipboard = (ClipboardManager) getSystemService(CLIPBOARD_SERVICE);
+            ClipData clip = ClipData.newPlainText("Error information", errorInformation);
+            clipboard.setPrimaryClip(clip);
         }
     }
 }

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -22,4 +22,6 @@
     <string name="customactivityoncrash_error_activity_error_details">Error details</string>
     <string name="customactivityoncrash_error_activity_error_details_title">Error details</string>
     <string name="customactivityoncrash_error_activity_error_details_close">Close</string>
+    <string name="customactivityoncrash_error_activity_error_details_copy">Copy to clipboard</string>
+    <string name="customactivityoncrash_error_activity_error_details_copied">Copied to clipboard</string>
 </resources>


### PR DESCRIPTION
Added a button to the error information AlertDialog to copy the error text to the clipboard.

I thought of it when I first tried the library, and then I saw #10 so I decided to do it myself. Hope you like it.

Closes #10 

![screenshot_20150812-222020](https://cloud.githubusercontent.com/assets/545251/9235760/16d477d4-4141-11e5-994f-173831a98b69.png)
