### PR TITLE
Bump targrt SDK to 34 and update AGP to gradle v8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.1'
+        classpath 'com.android.tools.build:gradle:8.4.0'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,6 @@
 # org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonTransitiveRClass=false
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 32
+    compileSdk 34
     resourcePrefix 'customactivityoncrash_'
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 34
     }
     namespace 'cat.ereza.customactivityoncrash'
 }
@@ -20,5 +20,5 @@ ext {
 apply from: "publish-mavencentral.gradle"
 
 dependencies {
-    api 'androidx.appcompat:appcompat:1.4.1'
+    api 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/library/publish-mavencentral.gradle
+++ b/library/publish-mavencentral.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.source
 }
 

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 32
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 32
+        targetSdkVersion 34
         versionCode 13
         versionName "2.4.0-SNAPSHOT"
     }


### PR DESCRIPTION
Hi! First off, thanks for this amazing library! I've been using it for a long time in my apps since it makes debugging so much easier. Users can easily see and copy relevant crash logs from crash-activity when submitting bug reports without dealing with things like ADB logcat and other third-party logger apps. 

I've noticed that there haven't been any updates to this library in the past two years. While the library still works as expected, the target SDK version has become outdated, as Google Play now requires apps to target at least SDK 33. Additionally, the Gradle plugin was also around three years old. So, I've updated both of them and properly replaced deprecated properties with their alternatives.